### PR TITLE
Swap formatter for template in the example

### DIFF
--- a/1.2/interaction.md
+++ b/1.2/interaction.md
@@ -27,7 +27,7 @@ payload for a layer:
 Example response from `layer.json`:
 
     {
-        "formatter": "{{NAME}}",
+        "template": "{{NAME}}",
         "legend": "<strong>Countries of the World</strong>"
     }
 


### PR DESCRIPTION
The value has been changed to a mustache template, without the corresponding change being made to the key. This change aligns the example with the surrounding text.
